### PR TITLE
Add TLS connection for PostgreSQL

### DIFF
--- a/charts/matrix/Chart.yaml
+++ b/charts/matrix/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 
 type: application
 
-version: 5.1.0
+version: 5.2.0
 
 # renovate: image=matrixdotorg/synapse
 appVersion: v1.95.1

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -1,6 +1,6 @@
 # matrix
 
-![Version: 5.1.0](https://img.shields.io/badge/Version-5.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.1](https://img.shields.io/badge/AppVersion-v1.95.1-informational?style=flat-square)
+![Version: 5.2.0](https://img.shields.io/badge/Version-5.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.1](https://img.shields.io/badge/AppVersion-v1.95.1-informational?style=flat-square)
 
 A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 
@@ -306,6 +306,10 @@ A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 | postgresql.primary.podSecurityContext.enabled | bool | `true` |  |
 | postgresql.primary.podSecurityContext.fsGroup | int | `1000` |  |
 | postgresql.primary.podSecurityContext.runAsUser | int | `1000` |  |
+| postgresql.sslcert | string | `""` |  |
+| postgresql.sslkey | string | `""` |  |
+| postgresql.sslmode | string | `""` | optional SSL parameters for postgresql, if using your own db instead of the subchart see more: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS |
+| postgresql.sslrootcert | string | `""` |  |
 | postgresql.volumePermissions.enabled | bool | `true` | Enable init container that changes the owner and group of the PVC |
 | s3.bucket | string | `""` | name of the bucket to use |
 | s3.cronjob.enabled | bool | `false` | enable a regular cleanup k8s cronjob to automatically backup everything to your s3 bucket for you and delete it from local disk ref: https://github.com/matrix-org/synapse-s3-storage-provider/tree/main#regular-cleanup-job |
@@ -316,8 +320,9 @@ A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 | s3.existingSecret | string | `""` | use credentials from an existing kubernetes secret |
 | s3.secretKeys.accessKey | string | `"S3_ACCESS_KEY"` | key in existing secret fo the S3 key |
 | s3.secretKeys.secretKey | string | `"S3_SECRET_KEY"` | key in existing secret fo the S3 secret |
-| synapse.extraVolumeMounts | list | `[]` |  |
-| synapse.extraVolumes | list | `[]` |  |
+| synapse.extraEnv | list | `[]` | optiona: extra env variables to pass to the matrix synapse deployment |
+| synapse.extraVolumeMounts | list | `[]` | optional: extra volume mounts for the matrix synapse deployment |
+| synapse.extraVolumes | list | `[]` | optional: extra volumes for the matrix synapse deployment |
 | synapse.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy for synapse image, Use Always if using image.tag: latest |
 | synapse.image.repository | string | `"matrixdotorg/synapse"` | image registry and repository to use for synapse |
 | synapse.image.tag | string | `""` | tag of synapse docker image to use. change this to latest to grab the    cutting-edge release of synapse |

--- a/charts/matrix/templates/synapse/_homeserver.yaml
+++ b/charts/matrix/templates/synapse/_homeserver.yaml
@@ -603,7 +603,18 @@ database:
         database: "REPLACE_ME"
         host: "REPLACE_ME"
         port: {{ .Values.postgresql.port }}
+        {{- if .Values.postgresql.sslmode }}
         sslmode: {{ .Values.postgresql.sslmode }}
+        {{- end }}
+        {{- if .Values.postgresql.sslkey }}
+        sslkey: {{ .Values.postgresql.sslkey }}
+        {{- end }}
+        {{- if .Values.postgresql.sslcert }}
+        sslcert: {{ .Values.postgresql.sslcert }}
+        {{- end }}
+        {{- if .Values.postgresql.sslrootcert }}
+        sslrootcert: {{ .Values.postgresql.sslrootcert }}
+        {{- end }}
         cp_min: 5
         cp_max: 10
 

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -55,6 +55,16 @@ spec:
                   name: {{ include "matrix.postgresql.secretName" . }}
                   key: {{ .Values.postgresql.global.postgresql.auth.secretKeys.databaseHostname }}
               {{- end }}
+            {{- if .Values.postgresql.sslmode }}
+            - name: PGSSLMODE
+              value: {{ .Values.postgresql.sslmode }}
+            - name: PGSSLCERT
+              value: {{ .Values.postgresql.sslcert }}
+            - name: PGSSLKEY
+              value: {{ .Values.postgresql.sslkey }}
+            - name: PGSSLROOTCERT
+              value: {{ .Values.postgresql.sslrootcert }}
+            {{- end }}
           command:
             - "sh"
             - "-c"

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -281,7 +281,7 @@ spec:
             - name: PGSSLROOTCERT
               value: {{ .Values.postgresql.sslrootcert }}
             {{- end }}
-            {{- if .Values.matrix.extraEnv }}
+            {{- if .Values.synapse.extraEnv }}
             {{- toYaml .Values.synapse.extraEnv | nindent 12 }}
             {{- end }}
           ports:

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -261,6 +261,9 @@ spec:
                   name: {{ .Values.s3.existingSecret }}
                   key: {{ .Values.s3.secretKeys.secretKey }}
             {{- end }}
+            {{- if .Values.matrix.extraEnv }}
+            {{- toYaml .Values.synapse.extraEnv | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8008

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -261,6 +261,16 @@ spec:
                   name: {{ .Values.s3.existingSecret }}
                   key: {{ .Values.s3.secretKeys.secretKey }}
             {{- end }}
+            {{- if .Values.postgresql.sslmode }}
+            - name: PGSSLMODE
+              value: {{ .Values.postgresql.sslmode }}
+            - name: PGSSLCERT
+              value: {{ .Values.postgresql.sslcert }}
+            - name: PGSSLKEY
+              value: {{ .Values.postgresql.sslkey }}
+            - name: PGSSLROOTCERT
+              value: {{ .Values.postgresql.sslrootcert }}
+            {{- end }}
             {{- if .Values.matrix.extraEnv }}
             {{- toYaml .Values.synapse.extraEnv | nindent 12 }}
             {{- end }}

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -391,6 +391,13 @@ postgresql:
   # If disabled, make sure PostgreSQL is available at the hostname below and
   # credentials are configured under postgresql.global.postgresql.auth
   enabled: true
+  # -- optional SSL parameters for postgresql, if using your own db instead of the subchart
+  # see more: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
+  sslmode: ""
+  sslrootcert: ""
+  sslcert: ""
+  sslkey: ""
+  # only used for bitnami postgres chart
   volumePermissions:
     # -- Enable init container that changes the owner and group of the PVC
     enabled: true
@@ -529,9 +536,13 @@ synapse:
     port: 9092
     annotations: true
 
+  # -- optiona: extra env variables to pass to the matrix synapse deployment
+  extraEnv: []
+
+  # -- optional: extra volumes for the matrix synapse deployment
   extraVolumes: []
 
-
+  # -- optional: extra volume mounts for the matrix synapse deployment
   extraVolumeMounts: []
 
 # Element client configuration. see: https://element.io/


### PR DESCRIPTION
Uses a combination of the PG env vars:
https://www.postgresql.org/docs/current/libpq-envars.html

And also the normal postgres parameters, as per the docs here:
https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html?highlight=database#database-1

and here:
https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS

so you can how pass in the following extra parameters related to TLS/SSL connections to PostgreSQL:

```yaml
postgresql:
  enabled: false
  # -- optional SSL parameters for postgresql, if using your own db instead of the subchart
  # see more: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
  sslmode: "verify-full"
  # each of these paths can be mounted via synapse.extraVolumes and synapse.extraVolumeMounts
  sslrootcert: "/some/path"
  sslcert: "/some/path"
  sslkey: "/some/path"
```

Also added an option for `synapse.extraEnv` in case you want to pass along extra env vars to the matrix container.