### PR TITLE
Separate `postgresql` and `externalDatabase` for synapse

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,20 @@ helm install my-release-name matrix/matrix --values values.yaml
 - Use (existing) Kubernetes Secrets for confidential data, such as passwords
 - Use OIDC configs for SSO (see synapse [docs](https://github.com/matrix-org/synapse/blob/747416e94cd8f137b9173c132f7c44ea1c59534d/docs/openid.md) for more info)
 - Latest version of [Element](https://element.io/)
-- [Bitnami PostgreSQL subchart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) to deploy a cluster - needs some work to standardize though, so we also support external postgresql servers
 - [Coturn TURN server subchart](https://github.com/jessebot/coturn-chart) for VoIP calls
 - Use [s3 to store stuff](https://github.com/matrix-org/synapse-s3-storage-provider/tree/main)
 - Use an existing Kubernetes Secret for an external mail server for email notifications
 
-#### ⚠️ Optional Features (Untested Since Fork)
+#### Databases
+
+You must select one of the following options:
+
+- Use the [Bitnami PostgreSQL subchart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) (set `postgresql.enabled` to `true`)
+- Use your own external database, which should also be PostgreSQL. (set `externalDatabase.enabled` to `true`)
+
+Note: you cannot enable both `externalDatabase` and `postgresql`. You must select _one_.
+
+### ⚠️ Optional Features (Untested Since Fork)
 
 These features still need to be tested, but are technically baked into the chart from the fork:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ helm install my-release-name matrix/matrix --values values.yaml
 You must select one of the following options:
 
 - Use the [Bitnami PostgreSQL subchart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) (set `postgresql.enabled` to `true`)
-- Use your own external database, which should also be PostgreSQL. (set `externalDatabase.enabled` to `true`)
+- Use your own external database, which can also be PostgreSQL. (set `externalDatabase.enabled` to `true`)
 
 Note: you cannot enable both `externalDatabase` and `postgresql`. You must select _one_.
 

--- a/charts/matrix/Chart.yaml
+++ b/charts/matrix/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 
 type: application
 
-version: 5.2.0
+version: 6.0.0
 
 # renovate: image=matrixdotorg/synapse
 appVersion: v1.95.1

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -1,6 +1,6 @@
 # matrix
 
-![Version: 5.2.0](https://img.shields.io/badge/Version-5.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.1](https://img.shields.io/badge/AppVersion-v1.95.1-informational?style=flat-square)
+![Version: 6.0.0](https://img.shields.io/badge/Version-6.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.1](https://img.shields.io/badge/AppVersion-v1.95.1-informational?style=flat-square)
 
 A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 
@@ -189,6 +189,22 @@ A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 | element.service.port | int | `80` |  |
 | element.service.type | string | `"ClusterIP"` |  |
 | element.welcomeUserId | string | `""` | Set to the user ID (@username:domain.tld) of a bot to invite all new users to a DM with the bot upon registration |
+| externalDatabase.database | string | `"matrix"` | name of the database to try and connect to |
+| externalDatabase.enabled | bool | `false` | enable using an external database instead of the Bitnami PostgreSQL sub-chart |
+| externalDatabase.existingSecret | string | `""` | Name of existing secret to use for PostgreSQL credentials |
+| externalDatabase.hostname | string | `""` | hostname of db server. Can be left blank if using postgres subchart |
+| externalDatabase.password | string | `"changeme"` | password of matrix postgres user - ignored using exsitingSecret |
+| externalDatabase.port | int | `5432` | which port to use to connect to your database server |
+| externalDatabase.secretKeys.adminPasswordKey | string | `"postgresPassword"` | key in existingSecret with the admin postgresql password |
+| externalDatabase.secretKeys.database | string | `"database"` | key in existingSecret with name of the database |
+| externalDatabase.secretKeys.databaseHostname | string | `"hostname"` | key in existingSecret with hostname of the database |
+| externalDatabase.secretKeys.databaseUsername | string | `"username"` | key in existingSecret with username for matrix to connect to db |
+| externalDatabase.secretKeys.userPasswordKey | string | `"password"` | key in existingSecret with password for matrix to connect to db |
+| externalDatabase.sslcert | string | `""` | optional: tls/ssl cert for postgresql connections |
+| externalDatabase.sslkey | string | `""` | optional: tls/ssl key for postgresql connections |
+| externalDatabase.sslmode | string | `""` | sslmode to use, example: verify-full |
+| externalDatabase.sslrootcert | string | `""` | optional: tls/ssl root cert for postgresql connections |
+| externalDatabase.username | string | `"matrix"` | username of matrix postgres user |
 | fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | mail.elementUrl | string | `""` | Optional: Element instance URL. If ingress is enabled, this is unnecessary, else if this is empty, emails will contain a link to https://app.element.io |
@@ -288,9 +304,8 @@ A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 | matrix.urlPreviews.rules.url | object | `{}` | Whitelist and blacklist based on URL pattern matching |
 | nameOverride | string | `""` |  |
 | networkPolicies.enabled | bool | `true` | whether to enable kubernetes network policies or not |
-| postgresql.enabled | bool | `true` | Whether to deploy the stable/postgresql chart with this chart. If disabled, make sure PostgreSQL is available at the hostname below and credentials are configured under postgresql.global.postgresql.auth |
+| postgresql.enabled | bool | `true` | Whether to deploy the stable/postgresql chart with this chart. If disabled, make sure all externalDatabase are filled out |
 | postgresql.global.postgresql.auth.existingSecret | string | `""` | Name of existing secret to use for PostgreSQL credentials |
-| postgresql.global.postgresql.auth.hostname | string | `""` | hostname of db server. Can be left blank if using postgres subchart |
 | postgresql.global.postgresql.auth.password | string | `"changeme"` | password of matrix postgres user - ignored using exsitingSecret |
 | postgresql.global.postgresql.auth.port | int | `5432` | which port to use to connect to your database server |
 | postgresql.global.postgresql.auth.secretKeys.adminPasswordKey | string | `"postgresPassword"` | key in existingSecret with the admin postgresql password |
@@ -306,10 +321,6 @@ A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 | postgresql.primary.podSecurityContext.enabled | bool | `true` |  |
 | postgresql.primary.podSecurityContext.fsGroup | int | `1000` |  |
 | postgresql.primary.podSecurityContext.runAsUser | int | `1000` |  |
-| postgresql.sslcert | string | `""` |  |
-| postgresql.sslkey | string | `""` |  |
-| postgresql.sslmode | string | `""` | optional SSL parameters for postgresql, if using your own db instead of the subchart see more: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS |
-| postgresql.sslrootcert | string | `""` |  |
 | postgresql.volumePermissions.enabled | bool | `true` | Enable init container that changes the owner and group of the PVC |
 | s3.bucket | string | `""` | name of the bucket to use |
 | s3.cronjob.enabled | bool | `false` | enable a regular cleanup k8s cronjob to automatically backup everything to your s3 bucket for you and delete it from local disk ref: https://github.com/matrix-org/synapse-s3-storage-provider/tree/main#regular-cleanup-job |

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -190,7 +190,7 @@ A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 | element.service.type | string | `"ClusterIP"` |  |
 | element.welcomeUserId | string | `""` | Set to the user ID (@username:domain.tld) of a bot to invite all new users to a DM with the bot upon registration |
 | externalDatabase.database | string | `"matrix"` | name of the database to try and connect to |
-| externalDatabase.enabled | bool | `false` | enable using an external database instead of the Bitnami PostgreSQL sub-chart |
+| externalDatabase.enabled | bool | `false` | enable using an external database *instead of* the Bitnami PostgreSQL sub-chart if externalDatabase.enabled is set to true, postgresql.enabled must be set to false |
 | externalDatabase.existingSecret | string | `""` | Name of existing secret to use for PostgreSQL credentials |
 | externalDatabase.hostname | string | `""` | hostname of db server. Can be left blank if using postgres subchart |
 | externalDatabase.password | string | `"changeme"` | password of matrix postgres user - ignored using exsitingSecret |
@@ -304,7 +304,7 @@ A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 | matrix.urlPreviews.rules.url | object | `{}` | Whitelist and blacklist based on URL pattern matching |
 | nameOverride | string | `""` |  |
 | networkPolicies.enabled | bool | `true` | whether to enable kubernetes network policies or not |
-| postgresql.enabled | bool | `true` | Whether to deploy the stable/postgresql chart with this chart. If disabled, make sure all externalDatabase are filled out |
+| postgresql.enabled | bool | `true` | Whether to deploy the Bitnami Postgresql sub chart If postgresql.enabled is set to true, externalDatabase.enabled must be set to false else if externalDatabase.enabled is set to true, postgresql.enabled must be set to false |
 | postgresql.global.postgresql.auth.existingSecret | string | `""` | Name of existing secret to use for PostgreSQL credentials |
 | postgresql.global.postgresql.auth.password | string | `"changeme"` | password of matrix postgres user - ignored using exsitingSecret |
 | postgresql.global.postgresql.auth.port | int | `5432` | which port to use to connect to your database server |

--- a/charts/matrix/templates/_helpers.tpl
+++ b/charts/matrix/templates/_helpers.tpl
@@ -121,6 +121,8 @@ Helper function to get the postgres secret containing the database credentials
 {{- define "matrix.postgresql.secretName" -}}
 {{- if and .Values.postgresql.enabled .Values.postgresql.global.postgresql.auth.existingSecret -}}
 {{ .Values.postgresql.global.postgresql.auth.existingSecret }}
+{{- else if and .Values.externalDatabase.enabled .Values.externalDatabase.existingSecret -}}
+{{ .Values.externalDatabase.existingSecret }}
 {{- else -}}
 {{ template "matrix.fullname" . }}-db-secret
 {{- end }}

--- a/charts/matrix/templates/synapse/_homeserver.yaml
+++ b/charts/matrix/templates/synapse/_homeserver.yaml
@@ -602,18 +602,22 @@ database:
         password: "REPLACE_ME"
         database: "REPLACE_ME"
         host: "REPLACE_ME"
+        {{- if .Values.postgresql.enabled }}
         port: {{ .Values.postgresql.port }}
-        {{- if .Values.postgresql.sslmode }}
-        sslmode: {{ .Values.postgresql.sslmode }}
+        {{- else if .Values.externalDatabase.enabled }}
+        port: {{ .Values.externalDatabase.port }}
         {{- end }}
-        {{- if .Values.postgresql.sslkey }}
-        sslkey: {{ .Values.postgresql.sslkey }}
+        {{- if .Values.externalDatabase.sslmode }}
+        sslmode: {{ .Values.externalDatabase.sslmode }}
         {{- end }}
-        {{- if .Values.postgresql.sslcert }}
-        sslcert: {{ .Values.postgresql.sslcert }}
+        {{- if .Values.externalDatabase.sslkey }}
+        sslkey: {{ .Values.externalDatabase.sslkey }}
         {{- end }}
-        {{- if .Values.postgresql.sslrootcert }}
-        sslrootcert: {{ .Values.postgresql.sslrootcert }}
+        {{- if .Values.externalDatabase.sslcert }}
+        sslcert: {{ .Values.externalDatabase.sslcert }}
+        {{- end }}
+        {{- if .Values.externalDatabase.sslrootcert }}
+        sslrootcert: {{ .Values.externalDatabase.sslrootcert }}
         {{- end }}
         cp_min: 5
         cp_max: 10

--- a/charts/matrix/templates/synapse/database-secret.yaml
+++ b/charts/matrix/templates/synapse/database-secret.yaml
@@ -2,7 +2,7 @@
 if postgresql.global.postgresql.auth.existingSecret is not passed in, then we create a
 secret to store the credentials without it being in a configmap in plaintext.
 */}}
-{{- if and .Values.postgresql.enabled (not .Values.postgresql.global.postgresql.auth.existingSecret) }}
+{{- if and (not .Values.postgresql.global.postgresql.auth.existingSecret) (not .Values.externalDatabase.existingSecret )}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,9 +14,13 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
-  {{- if not .Values.postgresql.global.postgresql.auth.existingSecret }}
+  {{- if and .Values.postgresql.enabled (not .Values.postgresql.global.postgresql.auth.existingSecret) }}
   database: {{ "matrix" | b64enc | quote }}
   username: {{ .Values.postgresql.global.postgresql.auth.username | b64enc | quote }}
   password: {{ .Values.postgresql.global.postgresql.auth.password | b64enc | quote }}
+  {{- else if and .Values.externalDatabase.enabled (not .Values.externalDatabase.existingSecret) }}
+  database: {{ .Values.externalDatabase.database | b64enc | quote }}
+  username: {{ .Values.externalDatabase.username | b64enc | quote }}
+  password: {{ .Values.externalDatabase.password | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -74,15 +74,9 @@ spec:
           image: "mikefarah/yq:latest"
           imagePullPolicy: Always
           env:
+            {{- if .Values.postgresql.enabled }}
             - name: DATABASE_HOSTNAME
-              {{- if .Values.postgresql.enabled }}
               value: {{ template "postgresql.v1.primary.fullname" .Subcharts.postgresql }}
-              {{ else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "matrix.postgresql.secretName" . }}
-                  key: {{ .Values.postgresql.global.postgresql.auth.secretKeys.databaseHostname }}
-              {{- end }}
             - name: DATABASE
               valueFrom:
                 secretKeyRef:
@@ -98,6 +92,28 @@ spec:
                 secretKeyRef:
                   name: {{ include "matrix.postgresql.secretName" . }}
                   key: {{ .Values.postgresql.global.postgresql.auth.secretKeys.userPasswordKey}}
+            {{- else if .Values.externalDatabase.enabled }}
+            - name: DATABASE_HOSTNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "matrix.postgresql.secretName" . }}
+                  key: {{ .Values.externalDatabase.secretKeys.databaseHostname }}
+            - name: DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "matrix.postgresql.secretName" . }}
+                  key: {{ .Values.externalDatabase.secretKeys.database }}
+            - name: DATABASE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "matrix.postgresql.secretName" . }}
+                  key: {{ .Values.externalDatabase.secretKeys.databaseUsername }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "matrix.postgresql.secretName" . }}
+                  key: {{ .Values.externalDatabase.secretKeys.userPasswordKey}}
+            {{- end }}
             {{- if .Values.coturn.enabled }}
             - name: COTURN_SHARED_SECRET
               valueFrom:
@@ -271,15 +287,15 @@ spec:
                   name: {{ .Values.s3.existingSecret }}
                   key: {{ .Values.s3.secretKeys.secretKey }}
             {{- end }}
-            {{- if .Values.postgresql.sslmode }}
+            {{- if .Values.externalDatabase.sslmode }}
             - name: PGSSLMODE
-              value: {{ .Values.postgresql.sslmode }}
+              value: {{ .Values.externalDatabase.sslmode }}
             - name: PGSSLCERT
-              value: {{ .Values.postgresql.sslcert }}
+              value: {{ .Values.externalDatabase.sslcert }}
             - name: PGSSLKEY
-              value: {{ .Values.postgresql.sslkey }}
+              value: {{ .Values.externalDatabase.sslkey }}
             - name: PGSSLROOTCERT
-              value: {{ .Values.postgresql.sslrootcert }}
+              value: {{ .Values.externalDatabase.sslrootcert }}
             {{- end }}
             {{- if .Values.synapse.extraEnv }}
             {{- toYaml .Values.synapse.extraEnv | nindent 12 }}

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -384,20 +384,55 @@ volumes:
     existingClaim: ""
 
 
-# PostgreSQL Database configuration, for more options:
+externalDatabase:
+  # -- enable using an external database instead of the Bitnami PostgreSQL sub-chart
+  enabled: false
+  # optional SSL parameters for postgresql, if using your own db instead of the subchart
+  # ref: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
+  # -- sslmode to use, example: verify-full
+  sslmode: ""
+  # make sure any paths here are reflected in synapse.extraVolumes and synapse.extraVolumeMounts
+  # -- optional: tls/ssl root cert for postgresql connections
+  sslrootcert: ""
+  # -- optional: tls/ssl cert for postgresql connections
+  sslcert: ""
+  # -- optional: tls/ssl key for postgresql connections
+  sslkey: ""
+  # database credentials to use if you don't use an existingSecret
+  # -- username of matrix postgres user
+  username: matrix
+  # -- password of matrix postgres user - ignored using exsitingSecret
+  password: changeme
+  # -- which port to use to connect to your database server
+  port: 5432
+  # -- hostname of db server. Can be left blank if using postgres subchart
+  hostname: ""
+  # -- name of the database to try and connect to
+  database: "matrix"
+  # -- Name of existing secret to use for PostgreSQL credentials
+  existingSecret: ""
+  # if externalDatabase.existingSecret is provided, the following are ignored
+  # password, username, hostname, database
+  # secretKeys to grab from existingSecret
+  secretKeys:
+    # -- key in existingSecret with hostname of the database
+    databaseHostname: hostname
+    # -- key in existingSecret with name of the database
+    database: database
+    # -- key in existingSecret with username for matrix to connect to db
+    databaseUsername: username
+    # -- key in existingSecret with password for matrix to connect to db
+    userPasswordKey: password
+    # -- key in existingSecret with the admin postgresql password
+    adminPasswordKey: postgresPassword
+
+
+# PostgreSQL Database configuration for synapse, for more options:
 # https://github.com/bitnami/charts/tree/main/bitnami/postgresql
 postgresql:
   # -- Whether to deploy the stable/postgresql chart with this chart.
-  # If disabled, make sure PostgreSQL is available at the hostname below and
-  # credentials are configured under postgresql.global.postgresql.auth
+  # If disabled, make sure all externalDatabase are filled out
   enabled: true
-  # -- optional SSL parameters for postgresql, if using your own db instead of the subchart
-  # see more: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
-  sslmode: ""
-  sslrootcert: ""
-  sslcert: ""
-  sslkey: ""
-  # only used for bitnami postgres chart
   volumePermissions:
     # -- Enable init container that changes the owner and group of the PVC
     enabled: true
@@ -412,14 +447,11 @@ postgresql:
         password: changeme
         # -- which port to use to connect to your database server
         port: 5432
-        # -- hostname of db server. Can be left blank if using postgres subchart
-        hostname: ""
-
         # -- Name of existing secret to use for PostgreSQL credentials
         existingSecret: ""
         # secretKeys to grab from existingSecret
         # if postgresql.existingSecret is provided, the following are ignored
-        # postgresql.password/username/hostname/database/port
+        # postgresql.password/username/hostname/database
         secretKeys:
           # -- key in existingSecret with hostname of the database
           databaseHostname: hostname

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -385,7 +385,8 @@ volumes:
 
 
 externalDatabase:
-  # -- enable using an external database instead of the Bitnami PostgreSQL sub-chart
+  # -- enable using an external database *instead of* the Bitnami PostgreSQL sub-chart
+  # if externalDatabase.enabled is set to true, postgresql.enabled must be set to false
   enabled: false
   # optional SSL parameters for postgresql, if using your own db instead of the subchart
   # ref: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
@@ -430,8 +431,9 @@ externalDatabase:
 # PostgreSQL Database configuration for synapse, for more options:
 # https://github.com/bitnami/charts/tree/main/bitnami/postgresql
 postgresql:
-  # -- Whether to deploy the stable/postgresql chart with this chart.
-  # If disabled, make sure all externalDatabase are filled out
+  # -- Whether to deploy the Bitnami Postgresql sub chart
+  # If postgresql.enabled is set to true, externalDatabase.enabled must be set to false
+  # else if externalDatabase.enabled is set to true, postgresql.enabled must be set to false
   enabled: true
   volumePermissions:
     # -- Enable init container that changes the owner and group of the PVC


### PR DESCRIPTION
I felt like the previous method of using the `postgresql` parameter for both the subchart and the external database felt a little weird, so I've separated them both. You can now set _one_ of the following:

```yaml
# Bitnami PostgreSQL Subchart Configuration for synapse's database, for more options, see:
# https://github.com/bitnami/charts/tree/main/bitnami/postgresql
postgresql:
  # -- Weather to deploy the bitnami postgresql sub chart.
  # If postgresql.enabled is set to true, externalDatabase.enabled must be set to false
  # else, you must set externalDatabase.enabled to true
  enabled: true
  volumePermissions:
    # -- Enable init container that changes the owner and group of the PVC
    enabled: true
  global:
    postgresql:
      # global.postgresql.auth overrides postgresql.auth
      auth:
        # database credentials to use if you don't use an existingSecret
        # -- username of matrix postgres user
        username: matrix
        # -- password of matrix postgres user - ignored using exsitingSecret
        password: changeme
        # -- which port to use to connect to your database server
        port: 5432
        # -- Name of existing secret to use for PostgreSQL credentials
        existingSecret: ""
        # secretKeys to grab from existingSecret
        # if postgresql.existingSecret is provided, the following are ignored
        # postgresql.password/username/hostname/database
        secretKeys:
          # -- key in existingSecret with hostname of the database
          databaseHostname: hostname
          # -- key in existingSecret with name of the database
          database: database
          # -- key in existingSecret with username for matrix to connect to db
          databaseUsername: username
          # -- key in existingSecret with password for matrix to connect to db
          userPasswordKey: password
          # -- key in existingSecret with the admin postgresql password
          adminPasswordKey: postgresPassword

  # primary database node config
  primary:
    # -- persistent volume claim configuration for postgresql to persist data
    persistence:
      # -- Enable PostgreSQL Primary data persistence using PVC
      enabled: false
      # -- size of postgresql volume claim
      size: 8Gi

    # -- run the scripts in templates/postgresql/initdb-configmap.yaml
    # If using an external Postgres server, make sure to configure the database
    # ref: https://github.com/matrix-org/synapse/blob/master/docs/postgres.md
    initdb:
      scriptsConfigMap: "{{ .Release.Name }}-postgresql-initdb"

    podSecurityContext:
      enabled: true
      runAsUser: 1000
      fsGroup: 1000
```

OR to use an external database *instead of* the built in Bitnami hosted PostgreSQL subchart:

```yaml
# explicitly set to false because it's true by default
postgresql:
  enabled: false
  
externalDatabase:
  # -- enable using an external database *instead of* the Bitnami PostgreSQL sub-chart
  enabled: true
  # optional SSL parameters for postgresql, if using your own db instead of the subchart
  # ref: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
  # -- sslmode to use, example: verify-full
  sslmode: ""
  # make sure any paths here are reflected in synapse.extraVolumes and synapse.extraVolumeMounts
  # -- optional: tls/ssl root cert for postgresql connections
  sslrootcert: ""
  # -- optional: tls/ssl cert for postgresql connections
  sslcert: ""
  # -- optional: tls/ssl key for postgresql connections
  sslkey: ""
  # only used for bitnami postgres chart
  # database credentials to use if you don't use an existingSecret
  # -- username of matrix postgres user
  username: matrix
  # -- password of matrix postgres user - ignored using exsitingSecret
  password: changeme
  # -- which port to use to connect to your database server
  port: 5432
  # -- hostname of db server. Can be left blank if using postgres subchart
  hostname: ""
  # -- name of the database to try and connect to
  database: "matrix"
  # -- Name of existing secret to use for PostgreSQL credentials
  existingSecret: ""
  # if externalDatabase.existingSecret is provided, the following are ignored
  # password, username, hostname, database
  # secretKeys to grab from existingSecret
  secretKeys:
    # -- key in existingSecret with hostname of the database
    databaseHostname: hostname
    # -- key in existingSecret with name of the database
    database: database
    # -- key in existingSecret with username for matrix to connect to db
    databaseUsername: username
    # -- key in existingSecret with password for matrix to connect to db
    userPasswordKey: password
    # -- key in existingSecret with the admin postgresql password
    adminPasswordKey: postgresPassword
```

Hopefully I haven't made this more confusing, but the idea is that the parameters you use for bitnami are the not the same as other postgresql providers, so I don't want to muddy them over time, because for instance, bitnami uses `tls` parameters whereas most other postgres providers use `ssl`, because that's still what those parameters are called in postgresql proper. An example would be `sslmode`.

This should also open us up for an `externalDatabase.type` feature down the line, and we can support more database types that synapse supports.