### PR TITLE
Update/Add `synapse.podSecurityContext` vs `synapse.securityContext` and fix how we install extra pip packages

### DIFF
--- a/charts/matrix/Chart.yaml
+++ b/charts/matrix/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 
 type: application
 
-version: 6.1.1
+version: 6.2.0
 
 # renovate: image=matrixdotorg/synapse
 appVersion: v1.95.1

--- a/charts/matrix/Chart.yaml
+++ b/charts/matrix/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 
 type: application
 
-version: 6.1.0
+version: 6.1.1
 
 # renovate: image=matrixdotorg/synapse
 appVersion: v1.95.1

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -372,6 +372,9 @@ A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 | synapse.service.federation.type | string | `"ClusterIP"` |  |
 | synapse.service.port | int | `80` | service port for synapse |
 | synapse.service.type | string | `"ClusterIP"` | service type for synpase |
+| volumes.extraPipPackages.capacity | string | `"5Mi"` | Capacity of the signing key PVC. Note: 1Mi is more than enough, but some cloud providers set a min PVC size of 1Mi or 1Gi, adjust as necessary |
+| volumes.extraPipPackages.existingClaim | string | `""` | name of an existing persistent volume claim for synapse config file |
+| volumes.extraPipPackages.storageClass | string | `""` | Storage class (optional) |
 | volumes.media.capacity | string | `"10Gi"` | Capacity of the media PVC - ignored if using exsitingClaim |
 | volumes.media.existingClaim | string | `""` | name of an existing PVC to use for uploaded attachments and multimedia |
 | volumes.media.storageClass | string | `""` | Storage class of the media PVC - ignored if using exsitingClaim |

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -347,6 +347,12 @@ A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 | synapse.metrics.annotations | bool | `true` |  |
 | synapse.metrics.enabled | bool | `true` | Whether Synapse should capture metrics on an additional endpoint |
 | synapse.metrics.port | int | `9092` | Port to listen on for metrics scraping |
+| synapse.podSecurityContext | object | `{"env":false,"fsGroup":1000,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | securityContext for the entire synapse pod, including the all containers Does not work by default in all cloud providers, disable by default |
+| synapse.podSecurityContext.env | bool | `false` | Enable if your k8s environment allows containers to chuser/setuid https://github.com/matrix-org/synapse/blob/96cf81e312407f0caba1b45ba9899906b1dcc098/docker/start.py#L196 |
+| synapse.podSecurityContext.fsGroup | int | `1000` | A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows. |
+| synapse.podSecurityContext.runAsGroup | int | `1000` | group ID to run the synapse POD as |
+| synapse.podSecurityContext.runAsNonRoot | bool | `true` | Indicates that the pod's containers must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. |
+| synapse.podSecurityContext.runAsUser | int | `1000` | user ID to run the synapse POD as |
 | synapse.probes.liveness.periodSeconds | int | `10` | liveness probe seconds trying again |
 | synapse.probes.liveness.timeoutSeconds | int | `5` | liveness probe seconds before timing out |
 | synapse.probes.readiness.periodSeconds | int | `10` | readiness probe seconds trying again |
@@ -356,11 +362,12 @@ A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 | synapse.probes.startup.timeoutSeconds | int | `5` | startup probe seconds before timing out |
 | synapse.replicaCount | int | `1` |  |
 | synapse.resources | object | `{}` |  |
-| synapse.securityContext.env | bool | `false` | Enable if your k8s environment allows containers to chuser/setuid https://github.com/matrix-org/synapse/blob/96cf81e312407f0caba1b45ba9899906b1dcc098/docker/start.py#L196 |
-| synapse.securityContext.fsGroup | int | `1000` |  |
-| synapse.securityContext.runAsGroup | int | `1000` | group to run the synapse container as |
-| synapse.securityContext.runAsNonRoot | bool | `true` |  |
-| synapse.securityContext.runAsUser | int | `1000` | user to run the synapse container as |
+| synapse.securityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":false,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | securityContext for the synapse CONTAINER ONLY Does not work by default in all cloud providers, disable by default |
+| synapse.securityContext.allowPrivilegeEscalation | bool | `false` | AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows. |
+| synapse.securityContext.readOnlyRootFilesystem | bool | `false` | Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows. |
+| synapse.securityContext.runAsGroup | int | `1000` | group ID to run the synapse container as |
+| synapse.securityContext.runAsNonRoot | bool | `true` | Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. |
+| synapse.securityContext.runAsUser | int | `1000` | user ID to run the synapse container as |
 | synapse.service.federation.port | int | `80` |  |
 | synapse.service.federation.type | string | `"ClusterIP"` |  |
 | synapse.service.port | int | `80` | service port for synapse |

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -372,8 +372,8 @@ A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 | synapse.service.federation.type | string | `"ClusterIP"` |  |
 | synapse.service.port | int | `80` | service port for synapse |
 | synapse.service.type | string | `"ClusterIP"` | service type for synpase |
-| volumes.extraPipPackages.capacity | string | `"100Mi"` | Capacity of the signing key PVC. Note: 1Mi is more than enough, but some cloud providers set a min PVC size of 1Mi or 1Gi, adjust as necessary |
-| volumes.extraPipPackages.existingClaim | string | `""` | name of an existing persistent volume claim for synapse config file |
+| volumes.extraPipPackages.capacity | string | `"100Mi"` | Capacity of the extra pip packages PVC. Note: 1Mi is more than enough, but some cloud providers set a min PVC size of 1Mi or 1Gi, adjust as necessary |
+| volumes.extraPipPackages.existingClaim | string | `""` | name of an existing persistent volume claim for the extra pip packages |
 | volumes.extraPipPackages.storageClass | string | `""` | Storage class (optional) |
 | volumes.media.capacity | string | `"10Gi"` | Capacity of the media PVC - ignored if using exsitingClaim |
 | volumes.media.existingClaim | string | `""` | name of an existing PVC to use for uploaded attachments and multimedia |

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -1,6 +1,6 @@
 # matrix
 
-![Version: 6.1.1](https://img.shields.io/badge/Version-6.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.1](https://img.shields.io/badge/AppVersion-v1.95.1-informational?style=flat-square)
+![Version: 6.2.0](https://img.shields.io/badge/Version-6.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.1](https://img.shields.io/badge/AppVersion-v1.95.1-informational?style=flat-square)
 
 A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -372,7 +372,7 @@ A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 | synapse.service.federation.type | string | `"ClusterIP"` |  |
 | synapse.service.port | int | `80` | service port for synapse |
 | synapse.service.type | string | `"ClusterIP"` | service type for synpase |
-| volumes.extraPipPackages.capacity | string | `"5Mi"` | Capacity of the signing key PVC. Note: 1Mi is more than enough, but some cloud providers set a min PVC size of 1Mi or 1Gi, adjust as necessary |
+| volumes.extraPipPackages.capacity | string | `"100Mi"` | Capacity of the signing key PVC. Note: 1Mi is more than enough, but some cloud providers set a min PVC size of 1Mi or 1Gi, adjust as necessary |
 | volumes.extraPipPackages.existingClaim | string | `""` | name of an existing persistent volume claim for synapse config file |
 | volumes.extraPipPackages.storageClass | string | `""` | Storage class (optional) |
 | volumes.media.capacity | string | `"10Gi"` | Capacity of the media PVC - ignored if using exsitingClaim |

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -1,6 +1,6 @@
 # matrix
 
-![Version: 6.1.0](https://img.shields.io/badge/Version-6.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.1](https://img.shields.io/badge/AppVersion-v1.95.1-informational?style=flat-square)
+![Version: 6.1.1](https://img.shields.io/badge/Version-6.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.1](https://img.shields.io/badge/AppVersion-v1.95.1-informational?style=flat-square)
 
 A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -260,6 +260,7 @@ spec:
             - /bin/sh
             - -ec
             - |
+              ls -hal
               pip install --user synapse-s3-storage-provider
               start.py
           {{- end }}

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -324,7 +324,7 @@ spec:
             {{- end }}
             {{- if .Values.s3.enabled }}
             - name: PYTHONPATH
-              value: "$PYTHONPATH:/data/extra_pip_packages"
+              value: "/usr/local/lib/python3.11/site-packages:/data/extra_pip_packages/lib/python3.11/site-packages"
             {{- end }}
             {{- if .Values.synapse.extraEnv }}
             {{- toYaml .Values.synapse.extraEnv | nindent 12 }}

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -354,6 +354,9 @@ spec:
             capabilities:
               drop:
                 - ALL
+            runAsGroup: {{ .Values.synapse.securityContext.runAsGroup }}
+            runAsUser: {{ .Values.synapse.securityContext.runAsUser }}
+            runAsNonRoot: {{ .Values.synapse.securityContext.runAsNonRoot }}
             readOnlyRootFilesystem: {{ .Values.synapse.securityContext.readOnlyRootFilesystem }}
             allowPrivilegeEscalation: {{ .Values.synapse.securityContext.allowPrivilegeEscalation }}
           {{- with .Values.synapse.resources }}

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -257,8 +257,11 @@ spec:
           imagePullPolicy: {{ .Values.synapse.image.pullPolicy }}
           {{- if .Values.s3.enabled }}
           command:
+            - /bin/sh
+            - -ec
             - |
               pip install synapse-s3-storage-provider
+              start.py
           {{- end }}
           env:
             {{- if .Values.synapse.securityContext.env }}

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -260,7 +260,7 @@ spec:
             - /bin/sh
             - -ec
             - |
-              pip install synapse-s3-storage-provider
+              pip install --user synapse-s3-storage-provider
               start.py
           {{- end }}
           env:

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -260,8 +260,8 @@ spec:
             - /bin/sh
             - -ec
             - |
-              ls -hal
-              pip install --user synapse-s3-storage-provider
+              ls -hal /usr/local/lib/python3.11/site-packages
+              PYTHONUSERBASE=/usr/local/lib/python3.11/site-packages pip install --user synapse-s3-storage-provider
               start.py
           {{- end }}
           env:

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -406,6 +406,7 @@ spec:
             {{ else }}
             claimName: {{ .Values.volumes.signingKey.existingClaim }}
             {{- end }}
+        {{- if .Values.s3.enabled }}
         - name: extra-packages
           persistentVolumeClaim:
             {{- if .Values.volumes.extraPipPackages.existingClaim }}
@@ -413,6 +414,7 @@ spec:
             {{ else }}
             claimName: {{ include "matrix.fullname" . }}-extra-pip-packages
             {{- end }}
+        {{- end }}
         - name: media-store
           persistentVolumeClaim:
             {{- if not .Values.volumes.media.existingClaim }}

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -250,20 +250,38 @@ spec:
               mountPath: /data
             - name: signing-key
               mountPath: /data/keys
+        {{- if .Values.s3.enabled }}
+        - name: pip-install-extra-packages
+          image: {{ include "matrix.image" . }}
+          imagePullPolicy: {{ .Values.synapse.image.pullPolicy }}
+          env:
+            - name: SYNAPSE_SERVER_NAME
+              value: {{ .Values.matrix.serverName }}
+            - name: SYNAPSE_REPORT_STATS
+              value: {{ .Values.matrix.telemetry | ternary "yes" "no" | quote }}
+            - name: PYTHONUSERBASE
+              value: /data/extra_pip_packages 
+            - name: PIP_CACHE_DIR
+              value: /tmp
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              ls -hal /data
+              pip install --user synapse-s3-storage-provider
+          volumeMounts:
+            - name: synapse-config
+              mountPath: /data
+            - name: signing-key
+              mountPath: /data/keys
+            - name: extra-packages
+              mountPath: /data/extra_pip_packages
+          {{- end }}
       {{- end }} {{/* end if .Release.IsInstall */}}
       containers:
         - name: "synapse"
           image: {{ include "matrix.image" . }}
           imagePullPolicy: {{ .Values.synapse.image.pullPolicy }}
-          {{- if .Values.s3.enabled }}
-          command:
-            - /bin/sh
-            - -ec
-            - |
-              ls -hal /usr/local/lib/python3.11/site-packages
-              PYTHONUSERBASE=/usr/local/lib/python3.11/site-packages pip install --user synapse-s3-storage-provider
-              start.py
-          {{- end }}
           env:
             {{- if .Values.synapse.securityContext.env }}
             {{- if .Values.synapse.securityContext.runAsUser }}
@@ -298,6 +316,12 @@ spec:
             - name: PGSSLROOTCERT
               value: {{ .Values.externalDatabase.sslrootcert }}
             {{- end }}
+            {{- if .Values.s3.enabled }}
+            - name: PYTHONUSERBASE
+              value: /data/extra_pip_packages 
+            - name: PIP_CACHE_DIR
+              value: /tmp
+            {{- end }}
             {{- if .Values.synapse.extraEnv }}
             {{- toYaml .Values.synapse.extraEnv | nindent 12 }}
             {{- end }}
@@ -317,6 +341,10 @@ spec:
               mountPath: /data/keys
             - name: media-store
               mountPath: /data/media_store
+            {{- if .Values.s3.enabled }}
+            - name: extra-packages
+              mountPath: /data/extra_pip_packages
+            {{- end }}
             {{- if or .Values.bridges.whatsapp.enabled .Values.bridges.discord.enabled .Values.bridges.irc.enabled }}
             - name: bridges
               mountPath: /bridges
@@ -380,6 +408,13 @@ spec:
             claimName: {{ include "matrix.fullname" . }}-signing-key
             {{ else }}
             claimName: {{ .Values.volumes.signingKey.existingClaim }}
+            {{- end }}
+        - name: extra-packages
+          persistentVolumeClaim:
+            {{- if .Values.volumes.extraPipPackages.existingClaim }}
+            claimName: {{ .Values.volumes.extraPipPackages.existingClaim }}
+            {{ else }}
+            claimName: {{ include "matrix.fullname" . }}-extra-pip-packages
             {{- end }}
         - name: media-store
           persistentVolumeClaim:

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -267,7 +267,6 @@ spec:
             - /bin/sh
             - -ec
             - |
-              ls -hal /data
               pip install --user synapse-s3-storage-provider
           volumeMounts:
             - name: synapse-config

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -281,6 +281,13 @@ spec:
         - name: "synapse"
           image: {{ include "matrix.image" . }}
           imagePullPolicy: {{ .Values.synapse.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              echo $PYTHONPATH
+              pip list
+              start.py
           env:
             {{- if .Values.synapse.securityContext.env }}
             {{- if .Values.synapse.securityContext.runAsUser }}
@@ -317,7 +324,7 @@ spec:
             {{- end }}
             {{- if .Values.s3.enabled }}
             - name: PYTHONPATH
-              value: "/data/extra_pip_packages:$PYTHONPATH"
+              value: "$PYTHONPATH:/data/extra_pip_packages"
             {{- end }}
             {{- if .Values.synapse.extraEnv }}
             {{- toYaml .Values.synapse.extraEnv | nindent 12 }}

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -281,13 +281,6 @@ spec:
         - name: "synapse"
           image: {{ include "matrix.image" . }}
           imagePullPolicy: {{ .Values.synapse.image.pullPolicy }}
-          command:
-            - /bin/sh
-            - -ec
-            - |
-              echo $PYTHONPATH
-              pip list
-              start.py
           env:
             {{- if .Values.synapse.securityContext.env }}
             {{- if .Values.synapse.securityContext.runAsUser }}

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -24,17 +24,17 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        {{- if .Values.synapse.securityContext.runAsUser }}
-        runAsUser: {{ .Values.synapse.securityContext.runAsUser }}
+        {{- if .Values.synapse.podSecurityContext.runAsUser }}
+        runAsUser: {{ .Values.synapse.podSecurityContext.runAsUser }}
         {{- end }}
-        {{- if .Values.synapse.securityContext.runAsGroup }}
-        runAsGroup: {{ .Values.synapse.securityContext.runAsGroup }}
+        {{- if .Values.synapse.podSecurityContext.runAsGroup }}
+        runAsGroup: {{ .Values.synapse.podSecurityContext.runAsGroup }}
         {{- end }}
-        {{- if .Values.synapse.securityContext.fsGroup }}
-        fsGroup: {{ .Values.synapse.securityContext.fsGroup }}
+        {{- if .Values.synapse.podSecurityContext.fsGroup }}
+        fsGroup: {{ .Values.synapse.podSecurityContext.fsGroup }}
         {{- end}}
-        {{- if .Values.synapse.securityContext.runAsNonRoot }}
-        runAsNonRoot: {{ .Values.synapse.securityContext.runAsNonRoot }}
+        {{- if .Values.synapse.podSecurityContext.runAsNonRoot }}
+        runAsNonRoot: {{ .Values.synapse.podSecurityContext.runAsNonRoot }}
         {{- end }}
       initContainers:
         {{- if .Values.postgresql.enabled }}
@@ -354,8 +354,8 @@ spec:
             capabilities:
               drop:
                 - ALL
-            readOnlyRootFilesystem: true
-            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: {{ .Values.synapse.securityContext.readOnlyRootFilesystem }}
+            allowPrivilegeEscalation: {{ .Values.synapse.securityContext.allowPrivilegeEscalation }}
           {{- with .Values.synapse.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -316,10 +316,8 @@ spec:
               value: {{ .Values.externalDatabase.sslrootcert }}
             {{- end }}
             {{- if .Values.s3.enabled }}
-            - name: PYTHONUSERBASE
-              value: /data/extra_pip_packages 
-            - name: PIP_CACHE_DIR
-              value: /tmp
+            - name: PYTHONPATH
+              value: "/data/extra_pip_packages:$PYTHONPATH"
             {{- end }}
             {{- if .Values.synapse.extraEnv }}
             {{- toYaml .Values.synapse.extraEnv | nindent 12 }}

--- a/charts/matrix/templates/synapse/extra-pip-packages-pvc.yaml
+++ b/charts/matrix/templates/synapse/extra-pip-packages-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.volumes.extraPipPackages.existingClaim }}
+{{- if and .Values.s3.enabled (not .Values.volumes.extraPipPackages.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/matrix/templates/synapse/extra-pip-packages-pvc.yaml
+++ b/charts/matrix/templates/synapse/extra-pip-packages-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if not .Values.volumes.extraPipPackages.existingClaim }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "matrix.fullname" . }}-extra-pip-packages
+  labels:
+{{ include "matrix.labels" . | indent 4}}
+{{ include "matrix.synapse.labels" . | indent 4}}
+spec:
+  {{- if .Values.volumes.extraPipPackages.storageClass }}
+  storageClassName: {{ .Values.volumes.extraPipPackages.storageClass }}
+  {{- end }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.volumes.extraPipPackages.capacity }}
+{{- end }}

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -371,6 +371,14 @@ volumes:
     storageClass: ""
     # -- name of an existing persistent volume claim for synapse config file
     existingClaim: ""
+  extraPipPackages:
+    # -- Capacity of the signing key PVC. Note: 1Mi is more than enough, but
+    # some cloud providers set a min PVC size of 1Mi or 1Gi, adjust as necessary
+    capacity: 5Mi
+    # -- Storage class (optional)
+    storageClass: ""
+    # -- name of an existing persistent volume claim for synapse config file
+    existingClaim: ""
 
 
 externalDatabase:

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -371,13 +371,14 @@ volumes:
     storageClass: ""
     # -- name of an existing persistent volume claim for synapse config file
     existingClaim: ""
+  # optional PVC used only when s3.enabled is set to true, to install synapse-s3-storage-provider
   extraPipPackages:
-    # -- Capacity of the signing key PVC. Note: 1Mi is more than enough, but
+    # -- Capacity of the extra pip packages PVC. Note: 1Mi is more than enough, but
     # some cloud providers set a min PVC size of 1Mi or 1Gi, adjust as necessary
     capacity: 100Mi
     # -- Storage class (optional)
     storageClass: ""
-    # -- name of an existing persistent volume claim for synapse config file
+    # -- name of an existing persistent volume claim for the extra pip packages
     existingClaim: ""
 
 

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -374,7 +374,7 @@ volumes:
   extraPipPackages:
     # -- Capacity of the signing key PVC. Note: 1Mi is more than enough, but
     # some cloud providers set a min PVC size of 1Mi or 1Gi, adjust as necessary
-    capacity: 5Mi
+    capacity: 100Mi
     # -- Storage class (optional)
     storageClass: ""
     # -- name of an existing persistent volume claim for synapse config file

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -533,15 +533,32 @@ synapse:
       # -- liveness probe seconds trying again
       periodSeconds: 10
 
+
+  # -- securityContext for the synapse CONTAINER ONLY
   # Does not work by default in all cloud providers, disable by default
   securityContext:
-    # -- user to run the synapse container as
+    # -- user ID to run the synapse container as
     runAsUser: 1000
-    # -- group to run the synapse container as
+    # -- group ID to run the synapse container as
     runAsGroup: 1000
-    fsGroup: 1000
+    # -- Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed.
     runAsNonRoot: true
+    # -- Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
+    readOnlyRootFilesystem: false
+    # -- AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.
+    allowPrivilegeEscalation: false
 
+  # -- securityContext for the entire synapse pod, including the all containers
+  # Does not work by default in all cloud providers, disable by default
+  podSecurityContext:
+    # -- user ID to run the synapse POD as
+    runAsUser: 1000
+    # -- group ID to run the synapse POD as
+    runAsGroup: 1000
+    # -- A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+    fsGroup: 1000
+    # -- Indicates that the pod's containers must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed.
+    runAsNonRoot: true
     # -- Enable if your k8s environment allows containers to chuser/setuid
     # https://github.com/matrix-org/synapse/blob/96cf81e312407f0caba1b45ba9899906b1dcc098/docker/start.py#L196
     env: false


### PR DESCRIPTION
- Adds optional persistent volume claim (or you can use an `existingClaim`) for installing extra pip packages, namely the [synapse-s3-storage-provider](https://github.com/matrix-org/synapse-s3-storage-provider/tree/main) pip package

- cleans up and adds more `synapse.securityContext` values for the synapse container

- adds a `synapse.podSecurityContext` feature for setting all the PodSecurityContext values for ALL containers in the synpase pod

- cleans up the synapase deployment so that if you `s3.enabled` is `true`, we now create an init container to install the extra [synapse-s3-storage-provider](https://github.com/matrix-org/synapse-s3-storage-provider/tree/main) pip package into a special directory (`/data/extra_pip_packages`)

- if `s3.enabled` we pass an env var, `PYTHONPATH` with `/usr/local/lib/python3.11/site-packages:/data/extra_pip_packages/lib/python3.11/site-packages`

**NOTE: the `PYTHONPATH` trick is a hack, and will break when matrixdotorg/synapse updates to python 3.12 🤦  We need to figure out a way to get just the major and minor version of python, and NOT the patch version**