### PR TITLE
fix SMTP and S3 config generation and add s3.region, s3.sse_c_key, and s3.sse_algorithm

### DIFF
--- a/charts/matrix/Chart.yaml
+++ b/charts/matrix/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 
 type: application
 
-version: 6.2.0
+version: 6.2.1
 
 # renovate: image=matrixdotorg/synapse
 appVersion: v1.95.1

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -1,6 +1,6 @@
 # matrix
 
-![Version: 6.2.0](https://img.shields.io/badge/Version-6.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.1](https://img.shields.io/badge/AppVersion-v1.95.1-informational?style=flat-square)
+![Version: 6.2.1](https://img.shields.io/badge/Version-6.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.1](https://img.shields.io/badge/AppVersion-v1.95.1-informational?style=flat-square)
 
 A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 
@@ -328,8 +328,11 @@ A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 | s3.enabled | bool | `false` | enable s3 storage via https://github.com/matrix-org/synapse-s3-storage-provider |
 | s3.endpoint | string | `""` | your s3 endpoint |
 | s3.existingSecret | string | `""` | use credentials from an existing kubernetes secret |
+| s3.region | string | `""` | optional region to use for s3 |
 | s3.secretKeys.accessKey | string | `"S3_ACCESS_KEY"` | key in existing secret fo the S3 key |
 | s3.secretKeys.secretKey | string | `"S3_SECRET_KEY"` | key in existing secret fo the S3 secret |
+| s3.sse_algorithm | string | `"AES256"` | optional SSE-C algorithm - very likely AES256 |
+| s3.sse_c_key | string | `""` | optional Server Side Encryption for Customer-provided keys |
 | synapse.extraEnv | list | `[]` | optiona: extra env variables to pass to the matrix synapse deployment |
 | synapse.extraVolumeMounts | list | `[]` | optional: extra volume mounts for the matrix synapse deployment |
 | synapse.extraVolumes | list | `[]` | optional: extra volumes for the matrix synapse deployment |

--- a/charts/matrix/templates/synapse/_homeserver.yaml
+++ b/charts/matrix/templates/synapse/_homeserver.yaml
@@ -737,15 +737,28 @@ media_store_path: "/data/media_store"
 media_storage_providers:
   - module: s3_storage_provider.S3StorageProviderBackend
     # Whether to write new local files.
-    store_local: true
+    store_local: True
     # Whether to write new remote media
-    store_remote: true
+    store_remote: True
     # Whether to block upload requests waiting for write to this
     # provider to complete
-    store_synchronous: true
+    store_synchronous: True
     config:
-      endpoint_url: {{ .Values.s3.endpoint }}
       bucket: {{ .Values.s3.bucket }}
+      # All of the below options are optional, for use with non-AWS S3-like
+      # services, or to specify access tokens here instead of some external method.
+      {{- if .Values.s3.region }}
+      region_name: {{ .Values.s3.region }}
+      {{- end }}
+      endpoint_url: {{ .Values.s3.endpoint }}
+      access_key_id: ""
+      secret_access_key: ""
+      {{- if .Values.s3.sse_c_key }}
+      # Server Side Encryption for Customer-provided keys
+      sse_customer_key: {{ .Values.s3.sse_c_key }}
+      # Your SSE-C algorithm is very likely AES256
+      sse_customer_algo: {{ .Values.s3.sse_algorithm }}
+      {{- end }}
 {{- end }}
 
 # Directory where in-progress uploads are stored.

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -184,7 +184,19 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.mail.external.existingSecret }}
                   key: {{ .Values.mail.external.secretKeys.password }}
+            {{- end }}
+            {{- if .Values.s3.enabled }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.s3.existingSecret }}
+                  key: {{ .Values.s3.secretKeys.accessKey }}
 
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.s3.existingSecret }}
+                  key: {{ .Values.s3.secretKeys.secretKey }}
             {{- end }}
           command:
             - /bin/sh
@@ -212,15 +224,19 @@ spec:
               yq eval -i '.oidc_providers[0].userinfo_endpoint = env(USERINFO_ENDPOINT)' /data/homeserver.yaml && \
               {{- end }}
               {{- end }}
+              {{- if .Values.s3.enabled }}
+              yq eval -i '.media_storage_providers[0].config.access_key_id = env(AWS_ACCESS_KEY_ID)' /data/homeserver.yaml && \
+              yq eval -i '.media_storage_providers[0].config.secret_access_key = env(AWS_SECRET_ACCESS_KEY)' /data/homeserver.yaml && \
+              {{- end }}
+              {{- if and .Values.mail.enabled .Values.mail.external.existingSecret }}
+              yq eval -i '.email.smtp_host = env(SMTP_HOST)' /data/homeserver.yaml && \
+              yq eval -i '.email.smtp_user = env(SMTP_USER)' /data/homeserver.yaml && \
+              yq eval -i '.email.smtp_pass = env(SMTP_PASS)' /data/homeserver.yaml && \
+              {{- end }}
               yq eval -i '.database.args.host = env(DATABASE_HOSTNAME)' /data/homeserver.yaml && \
               yq eval -i '.database.args.database = env(DATABASE)' /data/homeserver.yaml && \
               yq eval -i '.database.args.user = env(DATABASE_USERNAME)' /data/homeserver.yaml && \
               yq eval -i '.database.args.password = env(DATABASE_PASSWORD)' /data/homeserver.yaml
-              {{- if and .Values.mail.enabled .Values.mail.external.existingSecret }}
-              yq eval -i '.email.smtp_host = env(SMTP_HOST)' /data/homeserver.yaml
-              yq eval -i '.email.smtp_user = env(SMTP_USER)' /data/homeserver.yaml
-              yq eval -i '.email.smtp_pass = env(SMTP_PASS)' /data/homeserver.yaml
-              {{- end }}
           volumeMounts:
             - name: synapse-initial-config
               mountPath: "/initial"
@@ -291,19 +307,6 @@ spec:
             - name: GID
               value: "{{ .Values.synapse.securityContext.runAsGroup }}"
             {{- end }}
-            {{- end }}
-            {{- if .Values.s3.enabled }}
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.s3.existingSecret }}
-                  key: {{ .Values.s3.secretKeys.accessKey }}
-
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.s3.existingSecret }}
-                  key: {{ .Values.s3.secretKeys.secretKey }}
             {{- end }}
             {{- if .Values.externalDatabase.sslmode }}
             - name: PGSSLMODE

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -326,6 +326,12 @@ s3:
   endpoint: ""
   # -- name of the bucket to use
   bucket: ""
+  # -- optional region to use for s3
+  region: ""
+  # -- optional Server Side Encryption for Customer-provided keys
+  sse_c_key: ""
+  # -- optional SSE-C algorithm - very likely AES256
+  sse_algorithm: "AES256"
   # -- use credentials from an existing kubernetes secret
   existingSecret: ""
   # these are the keys within the existing k8s secret to use for s3 credentials


### PR DESCRIPTION
Adds the following values:

- `s3.region`
- `s3.sse_c_key`
- `s3.sse_algorithm`

And then we also add comments and default values that match the usage docs here: https://github.com/matrix-org/synapse-s3-storage-provider#usage

Finally, I noticed that the SMTP credentials weren't getting replaced and apparently boto isn't picking up the env vars, so we `yq` both into place now and no longer pass those env vars to the primary container.