### PR TITLE
change synapse-s3-storage-provider config to take lowercase true and make store_local optional

### DIFF
--- a/charts/matrix/Chart.yaml
+++ b/charts/matrix/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 
 type: application
 
-version: 6.2.1
+version: 6.2.2
 
 # renovate: image=matrixdotorg/synapse
 appVersion: v1.95.1

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -1,6 +1,6 @@
 # matrix
 
-![Version: 6.2.1](https://img.shields.io/badge/Version-6.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.1](https://img.shields.io/badge/AppVersion-v1.95.1-informational?style=flat-square)
+![Version: 6.2.2](https://img.shields.io/badge/Version-6.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.1](https://img.shields.io/badge/AppVersion-v1.95.1-informational?style=flat-square)
 
 A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 
@@ -333,6 +333,7 @@ A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 | s3.secretKeys.secretKey | string | `"S3_SECRET_KEY"` | key in existing secret fo the S3 secret |
 | s3.sse_algorithm | string | `"AES256"` | optional SSE-C algorithm - very likely AES256 |
 | s3.sse_c_key | string | `""` | optional Server Side Encryption for Customer-provided keys |
+| s3.store_local | bool | `true` | whether to write storage locally to a volume (this is in addition to the s3 storage) |
 | synapse.extraEnv | list | `[]` | optiona: extra env variables to pass to the matrix synapse deployment |
 | synapse.extraVolumeMounts | list | `[]` | optional: extra volume mounts for the matrix synapse deployment |
 | synapse.extraVolumes | list | `[]` | optional: extra volumes for the matrix synapse deployment |

--- a/charts/matrix/templates/synapse/_homeserver.yaml
+++ b/charts/matrix/templates/synapse/_homeserver.yaml
@@ -737,12 +737,15 @@ media_store_path: "/data/media_store"
 media_storage_providers:
   - module: s3_storage_provider.S3StorageProviderBackend
     # Whether to write new local files.
-    store_local: True
+    {{- if .Values.s3.store_local }}
+    store_local: true
+    {{- else }}
+    store_local: false
+    {{- end }}
     # Whether to write new remote media
-    store_remote: True
-    # Whether to block upload requests waiting for write to this
-    # provider to complete
-    store_synchronous: True
+    store_remote: true
+    # Whether to block upload requests waiting for write to this provider to complete
+    store_synchronous: true
     config:
       bucket: {{ .Values.s3.bucket }}
       # All of the below options are optional, for use with non-AWS S3-like

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -322,6 +322,8 @@ matrix:
 s3:
   # -- enable s3 storage via https://github.com/matrix-org/synapse-s3-storage-provider
   enabled: false
+  # -- whether to write storage locally to a volume (this is in addition to the s3 storage)
+  store_local: true
   # -- your s3 endpoint
   endpoint: ""
   # -- name of the bucket to use


### PR DESCRIPTION
Really hoping this is the last s3 related chart change 🤦

Adds `s3.store_local` parameter to values.yaml and changes all the `True` to `true`, because I _think_ that's what you're supposed to do.

Opened this issue to verify: https://github.com/matrix-org/synapse-s3-storage-provider/issues/104