### PR TITLE
add optional prometheus `ServiceMonitor` for when `synapse.metrics.enabled` is set to true

### DIFF
--- a/charts/matrix/Chart.yaml
+++ b/charts/matrix/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 
 type: application
 
-version: 13.0.2
+version: 13.1.0
 
 # renovate: image=matrixdotorg/synapse
 appVersion: v1.109.0

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -1,6 +1,6 @@
 # matrix
 
-![Version: 13.0.2](https://img.shields.io/badge/Version-13.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.109.0](https://img.shields.io/badge/AppVersion-v1.109.0-informational?style=flat-square)
+![Version: 13.1.0](https://img.shields.io/badge/Version-13.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.109.0](https://img.shields.io/badge/AppVersion-v1.109.0-informational?style=flat-square)
 
 A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 
@@ -796,6 +796,7 @@ A Helm chart to deploy a Matrix homeserver stack on Kubernetes
 | synapse.metrics.annotations | bool | `true` |  |
 | synapse.metrics.enabled | bool | `true` | Whether Synapse should capture metrics on an additional endpoint |
 | synapse.metrics.port | int | `9092` | Port to listen on for metrics scraping |
+| synapse.metrics.serviceMonitor.enabled | bool | `false` | enable a prometheus ServiceMonitor to send metrics to prometheus |
 | synapse.podSecurityContext | object | `{"env":false,"fsGroup":1000,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | securityContext for the entire synapse pod, including the all containers Does not work by default in all cloud providers, disable by default |
 | synapse.podSecurityContext.env | bool | `false` | Enable if your k8s environment allows containers to chuser/setuid https://github.com/matrix-org/synapse/blob/96cf81e312407f0caba1b45ba9899906b1dcc098/docker/start.py#L196 |
 | synapse.podSecurityContext.fsGroup | int | `1000` | A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows. |

--- a/charts/matrix/templates/synapse/servicemonitor.yaml
+++ b/charts/matrix/templates/synapse/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.synapse.metrics.enabled .Values.synapse.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "matrix.fullname" . }}-synapse
+  labels:
+    {{- include "matrix.labels" . | indent 4 }}
+    {{- include "matrix.synapse.labels" . | indent 4}}
+spec:
+  endpoints:
+  - interval: 30s
+    targetPort: {{ .Values.synapse.metrics.port }}
+    path: /_synapse/metrics
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      {{- include "matrix.labels" . | indent 6 }}
+      {{- include "matrix.synapse.labels" . | indent 6 }}
+{{- end }}

--- a/charts/matrix/templates/synapse/servicemonitor.yaml
+++ b/charts/matrix/templates/synapse/servicemonitor.yaml
@@ -4,8 +4,8 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "matrix.fullname" . }}-synapse
   labels:
-    {{- include "matrix.labels" . | indent 4 }}
-    {{- include "matrix.synapse.labels" . | indent 4}}
+    {{- include "matrix.labels" . | nindent 4 }}
+    {{- include "matrix.synapse.labels" . | nindent 4}}
 spec:
   endpoints:
   - interval: 30s
@@ -16,6 +16,6 @@ spec:
       - {{ .Release.Namespace | quote }}
   selector:
     matchLabels:
-      {{- include "matrix.labels" . | indent 6 }}
-      {{- include "matrix.synapse.labels" . | indent 6 }}
+      {{- include "matrix.labels" . | nindent 6 }}
+      {{- include "matrix.synapse.labels" . | nindent 6 }}
 {{- end }}

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -771,6 +771,9 @@ synapse:
     # -- Port to listen on for metrics scraping
     port: 9092
     annotations: true
+    serviceMonitor:
+      # -- enable a prometheus ServiceMonitor to send metrics to prometheus
+      enabled: false
 
   # -- optiona: extra env variables to pass to the matrix synapse deployment
   extraEnv: []


### PR DESCRIPTION
You can now set `synapse.metrics.serviceMonitor.enabled` to `true` and we'll deploy a `ServiceMonitor` resource to listen in on your metrics endpoint. Via values.yaml that looks like this:

```yaml
synapse:
  metrics:
    enabled: true
    serviceMonitor:
      enabled: true
```