### PR TITLE
Fix postgres scriptsConfigMap name in values.yaml

### DIFF
--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -616,7 +616,7 @@ postgresql:
     # If using an external Postgres server, make sure to configure the database
     # ref: https://github.com/element-hq/synapse/blob/develop/docs/postgres.md
     initdb:
-      scriptsConfigMap: "{{ .Release.Name }}-postgresql-initdb"
+      scriptsConfigMap: "{{ .Release.Name }}-matrix-postgresql-initdb"
 
     podSecurityContext:
       enabled: true


### PR DESCRIPTION
When setting up this helm chart I noticed that there was a mismatch of the init DB config map IDs, so this MR should fix it.