### PR TITLE
No longer check if postgresql existingSecret has a custom hostname set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 .DS_Store
+.aider*

--- a/charts/matrix/Chart.yaml
+++ b/charts/matrix/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 
 type: application
 
-version: 18.4.0
+version: 18.4.1
 
 # renovate: image=ghcr.io/element-hq/synapse
 appVersion: v1.122.0

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -64,14 +64,7 @@ spec:
                   name: {{ include "matrix.postgresql.secretName" . }}
                   key: {{ .Values.postgresql.global.postgresql.auth.secretKeys.databaseUsername }}
             - name: DATABASE_HOSTNAME
-              {{- if or (not .Values.postgresql.global.postgresql.auth.existingSecret) .Values.postgresql.global.postgresql.generateHostname }}
               value: {{ template "postgresql.v1.primary.fullname" .Subcharts.postgresql }}
-              {{ else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "matrix.postgresql.secretName" . }}
-                  key: {{ .Values.postgresql.global.postgresql.auth.secretKeys.databaseHostname }}
-              {{- end }}
             {{- if .Values.postgresql.sslmode }}
             - name: PGSSLMODE
               value: {{ .Values.postgresql.sslmode }}

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -64,7 +64,7 @@ spec:
                   name: {{ include "matrix.postgresql.secretName" . }}
                   key: {{ .Values.postgresql.global.postgresql.auth.secretKeys.databaseUsername }}
             - name: DATABASE_HOSTNAME
-              {{- if not .Values.postgresql.global.postgresql.auth.existingSecret }}
+              {{- if or (not .Values.postgresql.global.postgresql.auth.existingSecret) .Values.postgresql.global.postgresql.generateHostname }}
               value: {{ template "postgresql.v1.primary.fullname" .Subcharts.postgresql }}
               {{ else }}
               valueFrom:


### PR DESCRIPTION
Currently, the first initContainer of the matrix-synapse deployment `postgresql-isready` tries to respect a potential `databaseHostname` environment variable, if `.Values.postgresql.global.postgresql.auth.existingSecret` is set. However, this had lead to a bit of a goose chase on my side, as trying to use `existingSecret` will produce the following error when trying to perform an ArgoCD sync:

```
Failed to compare desired state to live state: failed to calculate diff: error calculating server side diff: serverSideDiff error: error running server side apply in dryrun mode for resource Deployment/matrix-synapse-synapse: Deployment.apps "matrix-synapse-synapse" is invalid: spec.template.spec.initContainers[0].env[1].valueFrom: Invalid value: "": may not be specified when `value` is not empty
```

I found this issue really hard to debug, as running my Values-file from helm actually does not result in this issue. However, when playing around with a fork of this repo, I realized that the second initContainer `add-secret-vlaues-to-config` does not respect the `databaseHostbase` in the existingSecret, meaning that if someone where to make the first initContainer working with a custom databaseHostname, they would then realize that the second initContainer will always ignore their custom hostname anyways.

Therefore, I propose the "lazy fix" to also ignore a potential custom hostname in the first initContainer. This way, potential issues for users who just want to set a custom postgres password in `existingSecret` will be avoided. And it won't be a breaking change, as nobody could be using custom hostnames to begin with.