### PR TITLE
Allow external Coturn deployment

### DIFF
--- a/charts/matrix/templates/synapse/_homeserver.yaml
+++ b/charts/matrix/templates/synapse/_homeserver.yaml
@@ -904,8 +904,7 @@ max_spider_size: {{ .Values.matrix.urlPreviews.rules.maxSize }}
 # The API endpoint to use for verifying m.login.recaptcha responses.
 #
 #recaptcha_siteverify_api: "https://www.recaptcha.net/recaptcha/api/siteverify"
-
-{{- if .Values.coturn.enabled -}}
+{{- if or .Values.coturn.enabled .Values.coturn.external -}}
 
 ## TURN ##
 

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -1463,6 +1463,8 @@ element:
 coturn:
   # -- Set to false to disable the included deployment of Coturn
   enabled: false
+  # -- Set to true to use an external Coturn deployment
+  external: false
 
   certificate:
     # -- set to true to generate a TLS certificate for encrypted comms


### PR DESCRIPTION
Adds an option to values.yaml to enable configuring values in homeserver.yaml for an external Coturn deployment.